### PR TITLE
Properly support HAPI using CQL

### DIFF
--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/EvaluateCqlMeasure.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/EvaluateCqlMeasure.java
@@ -62,9 +62,6 @@ public class EvaluateCqlMeasure extends AbstractServiceDelegate implements Initi
     }
 
     private void validateMeasureReport(MeasureReport report) {
-        if (report.getDate() == null) {
-            throw new RuntimeException("Missing MeasureReport date");
-        }
         if (!report.hasGroup()) {
             throw new RuntimeException("Missing MeasureReport group");
         }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/StoreMeasureReport.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/StoreMeasureReport.java
@@ -1,18 +1,18 @@
 package de.medizininformatik_initiative.feasibility_dsf_process.service;
 
-import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.VARIABLE_MEASURE_REPORT;
-import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.VARIABLE_MEASURE_REPORT_ID;
-
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.highmed.dsf.bpe.delegate.AbstractServiceDelegate;
 import org.highmed.dsf.fhir.authorization.read.ReadAccessHelper;
 import org.highmed.dsf.fhir.client.FhirWebserviceClientProvider;
 import org.highmed.dsf.fhir.task.TaskHelper;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.*;
 
 public class StoreMeasureReport extends AbstractServiceDelegate implements InitializingBean
 {
@@ -29,7 +29,10 @@ public class StoreMeasureReport extends AbstractServiceDelegate implements Initi
 	protected void doExecute(DelegateExecution execution)
 	{
 		MeasureReport measureReport = (MeasureReport) execution.getVariable(VARIABLE_MEASURE_REPORT);
-        addReadAccessTag(measureReport);
+		Measure associatedMeasure = (Measure) execution.getVariable(VARIABLE_MEASURE);
+
+		addReadAccessTag(measureReport);
+		referenceZarsMeasure(measureReport, associatedMeasure);
 
 		IdType measureReportId = storeMeasureReport(measureReport);
 		logger.debug("Stored MeasureReport {}", measureReportId);
@@ -42,6 +45,10 @@ public class StoreMeasureReport extends AbstractServiceDelegate implements Initi
         String identifier = getLeadingTaskFromExecutionVariables().getRequester().getIdentifier().getValue();
         getReadAccessHelper().addOrganization(measureReport, identifier);
     }
+
+	private void referenceZarsMeasure(MeasureReport measureReport, Measure zarsMeasure) {
+		measureReport.setMeasure(zarsMeasure.getUrl());
+	}
 
 	private IdType storeMeasureReport(MeasureReport measureReport)
 	{

--- a/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/service/EvaluateCqlMeasureTest.java
+++ b/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/service/EvaluateCqlMeasureTest.java
@@ -91,7 +91,6 @@ public class EvaluateCqlMeasureTest {
     @Parameters(name = "{0}")
     public static Collection<Object[]> measureReports() {
         return Arrays.asList(new Object[][]{
-                {"MissingMeasureReportDate", Optional.of("Missing MeasureReport date"), new MeasureReport()},
                 {"MissingMeasureReportGroup", Optional.of("Missing MeasureReport group"), new MeasureReport()
                         .setDate(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")))},
                 {"MissingMeasureReportPopulation", Optional.of("Missing MeasureReport population"), new MeasureReport()

--- a/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/service/StoreMeasureReportTest.java
+++ b/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/service/StoreMeasureReportTest.java
@@ -1,38 +1,26 @@
 package de.medizininformatik_initiative.feasibility_dsf_process.service;
 
-import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.VARIABLE_MEASURE_REPORT;
-import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.VARIABLE_MEASURE_REPORT_ID;
-import static java.util.stream.Collectors.toList;
-import static org.highmed.dsf.bpe.ConstantsBase.BPMN_EXECUTION_VARIABLE_LEADING_TASK;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.highmed.dsf.fhir.authorization.read.ReadAccessHelper;
 import org.highmed.dsf.fhir.authorization.read.ReadAccessHelperImpl;
 import org.highmed.dsf.fhir.client.FhirWebserviceClientProvider;
 import org.highmed.fhir.client.FhirWebserviceClient;
 import org.highmed.fhir.client.PreferReturnMinimalWithRetry;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Element;
-import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.MeasureReport;
-import org.hl7.fhir.r4.model.Reference;
-import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.*;
+import static java.util.stream.Collectors.toList;
+import static org.highmed.dsf.bpe.ConstantsBase.BPMN_EXECUTION_VARIABLE_LEADING_TASK;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StoreMeasureReportTest
@@ -61,6 +49,10 @@ public class StoreMeasureReportTest
 	@Test
 	public void testDoExecute() throws Exception
 	{
+		var initialMeasureFromZars = new Measure();
+		var measureId = UUID.randomUUID();
+		initialMeasureFromZars.setId(new IdType(measureId.toString()));
+        initialMeasureFromZars.setUrl("http://some.domain/fhir/Measure/" + measureId);
 		MeasureReport measureReport = new MeasureReport();
 
 		Task task = new Task();
@@ -68,6 +60,7 @@ public class StoreMeasureReportTest
 				new Identifier().setSystem("http://localhost/systems/sample-system").setValue("requester-id"));
 		task.setRequester(requesterReference);
 
+        when(execution.getVariable(VARIABLE_MEASURE)).thenReturn(initialMeasureFromZars);
 		when(execution.getVariable(VARIABLE_MEASURE_REPORT)).thenReturn(measureReport);
 		when(execution.getVariable(BPMN_EXECUTION_VARIABLE_LEADING_TASK)).thenReturn(task);
 		when(clientProvider.getLocalWebserviceClient()).thenReturn(localWebserviceClient);
@@ -78,7 +71,11 @@ public class StoreMeasureReportTest
 
 		verify(execution).setVariable(VARIABLE_MEASURE_REPORT_ID, "id-094601");
 
-		List<Coding> tags =  measureReportCaptor.getValue().getMeta().getTag().stream().filter(c -> "http://highmed.org/fhir/CodeSystem/read-access-tag".equals(c.getSystem())).collect(toList());
+
+        var capturedMeasureReport = measureReportCaptor.getValue();
+        assertEquals("http://some.domain/fhir/Measure/" + measureId, capturedMeasureReport.getMeasure());
+
+        List<Coding> tags =  capturedMeasureReport.getMeta().getTag().stream().filter(c -> "http://highmed.org/fhir/CodeSystem/read-access-tag".equals(c.getSystem())).collect(toList());
 		assertEquals(2, tags.size());
 		assertEquals(1 , tags.stream().filter(c -> "LOCAL".equals(c.getCode())).count());
 


### PR DESCRIPTION
Fixes #8 

- splits bundle transaction into multiple smaller ones when storing feasibility resources in the actual FHIR store (site)
- uses the measure URL initially sent by the ZARS when storing a measure report
- relaxes the date constraint on measure reports (HAPI does not set this information which is valid by the specification)