### PR TITLE
Strip Evaluated Resources from MeasureReport

### DIFF
--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/StoreMeasureReport.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/StoreMeasureReport.java
@@ -12,6 +12,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
+import java.util.List;
+
 import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.*;
 
 public class StoreMeasureReport extends AbstractServiceDelegate implements InitializingBean
@@ -33,6 +35,7 @@ public class StoreMeasureReport extends AbstractServiceDelegate implements Initi
 
 		addReadAccessTag(measureReport);
 		referenceZarsMeasure(measureReport, associatedMeasure);
+		stripEvaluatedResources(measureReport);
 
 		IdType measureReportId = storeMeasureReport(measureReport);
 		logger.debug("Stored MeasureReport {}", measureReportId);
@@ -48,6 +51,10 @@ public class StoreMeasureReport extends AbstractServiceDelegate implements Initi
 
 	private void referenceZarsMeasure(MeasureReport measureReport, Measure zarsMeasure) {
 		measureReport.setMeasure(zarsMeasure.getUrl());
+	}
+
+	private void stripEvaluatedResources(MeasureReport measureReport) {
+		measureReport.setEvaluatedResource(List.of());
 	}
 
 	private IdType storeMeasureReport(MeasureReport measureReport)


### PR DESCRIPTION
Information about evaluated resources is mainly removed
due to HAPI using non-absolute references. This causes
errors down the line (FHIR inbox) since references cannot
be resolved (they are specific to the FHIR server who
was responsible for the evaluation).

Fixes #14 