### PR TITLE
Move Namespace to MII

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,16 @@
 /feasibility-dsf-process-docker-test-setup/dic-2/fhir/log/*.log
 /feasibility-dsf-process-docker-test-setup/dic-2/fhir/log/*.log.gz
 
+/feasibility-dsf-process-docker-test-setup/dic-3/bpe/last_event/time.file
+/feasibility-dsf-process-docker-test-setup/dic-3/bpe/log/*.log
+/feasibility-dsf-process-docker-test-setup/dic-3/bpe/log/*.log.gz
+/feasibility-dsf-process-docker-test-setup/dic-3/bpe/plugin/*.jar
+/feasibility-dsf-process-docker-test-setup/dic-3/bpe/process/*.jar
+/feasibility-dsf-process-docker-test-setup/dic-3/fhir/conf/bundle.xml
+/feasibility-dsf-process-docker-test-setup/dic-3/fhir/conf/config.properties
+/feasibility-dsf-process-docker-test-setup/dic-3/fhir/log/*.log
+/feasibility-dsf-process-docker-test-setup/dic-3/fhir/log/*.log.gz
+
 /feasibility-dsf-process-docker-test-setup/zars/bpe/last_event/time.file
 /feasibility-dsf-process-docker-test-setup/zars/bpe/log/*.log
 /feasibility-dsf-process-docker-test-setup/zars/bpe/log/*.log.gz

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Netzwerk Universitätsmedizin
+   Copyright 2021 Medizininformatik Initiative
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/feasibility-dsf-process-docker-test-setup/data/feasibility-bundle.json
+++ b/feasibility-dsf-process-docker-test-setup/data/feasibility-bundle.json
@@ -8,10 +8,10 @@
         "resourceType": "Task",
         "meta": {
           "profile": [
-            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-request-simple-feasibility"
+            "http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-request-simple-feasibility"
           ]
         },
-        "instantiatesUri": "http://www.netzwerk-universitaetsmedizin.de/bpe/Process/requestSimpleFeasibility/0.2.0",
+        "instantiatesUri": "http://medizininformatik-initiative.de/bpe/Process/requestSimpleFeasibility/0.2.0",
         "status": "requested",
         "intent": "order",
         "authoredOn": "2021",
@@ -60,7 +60,7 @@
             "type": {
               "coding": [
                 {
-                  "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility",
+                  "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility",
                   "code": "measure-reference"
                 }
               ]
@@ -88,7 +88,7 @@
             }
           ],
           "profile": [
-            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-measure"
+            "http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-measure"
           ]
         },
         "url": "https://zars/Measure/7a142223-616f-41a1-97da-2ae726031b71",
@@ -142,7 +142,7 @@
             }
           ],
           "profile": [
-            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-library"
+            "http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-library"
           ]
         },
         "url": "urn:uuid:30561ba6-106f-4d52-bb8d-e49e20a40d40",

--- a/feasibility-dsf-process-docker-test-setup/dic-1/flare/feasibility-code-tree.json
+++ b/feasibility-dsf-process-docker-test-setup/dic-1/flare/feasibility-code-tree.json
@@ -17857,7 +17857,7 @@
           "termCode": {
             "code": "1",
             "display": "Very Fit",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17865,7 +17865,7 @@
           "termCode": {
             "code": "2",
             "display": "Well",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17873,7 +17873,7 @@
           "termCode": {
             "code": "3",
             "display": "Managing Well",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17881,7 +17881,7 @@
           "termCode": {
             "code": "4",
             "display": "Vulnerable",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17889,7 +17889,7 @@
           "termCode": {
             "code": "5",
             "display": "Mildly Frail",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17897,7 +17897,7 @@
           "termCode": {
             "code": "6",
             "display": "Moderately Frail",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17905,7 +17905,7 @@
           "termCode": {
             "code": "7",
             "display": "Severely Frail",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17913,7 +17913,7 @@
           "termCode": {
             "code": "8",
             "display": "Very Severely Frail",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -17921,7 +17921,7 @@
           "termCode": {
             "code": "9",
             "display": "Terminally Ill",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/frailty-score"
           }
         },
         {
@@ -23075,7 +23075,7 @@
           "termCode": {
             "code": "02",
             "display": "Study enrolment due to Covid-19",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/ecrf-parameter-codes"
           }
         },
         {
@@ -23083,7 +23083,7 @@
           "termCode": {
             "code": "03",
             "display": "Interventional studies participation",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/ecrf-parameter-codes"
           }
         }
       ],
@@ -23574,7 +23574,7 @@
           "termCode": {
             "code": "06",
             "display": "SOFA-Score",
-            "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes"
+            "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/ecrf-parameter-codes"
           }
         },
         {

--- a/feasibility-dsf-process-docker-test-setup/dic-1/flare/feasibility-mapping.json
+++ b/feasibility-dsf-process-docker-test-setup/dic-1/flare/feasibility-mapping.json
@@ -28258,7 +28258,7 @@
     "key": {
       "code": "02",
       "display": "Study enrolment due to Covid-19",
-      "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes"
+      "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/ecrf-parameter-codes"
     },
     "termCodeSearchParameter": "code",
     "valueSearchParameter": "value-concept"
@@ -31464,7 +31464,7 @@
     "key": {
       "code": "03",
       "display": "Interventional studies participation",
-      "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes"
+      "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/ecrf-parameter-codes"
     },
     "termCodeSearchParameter": "code",
     "valueSearchParameter": "value-concept"
@@ -52883,7 +52883,7 @@
     "key": {
       "code": "06",
       "display": "SOFA-Score",
-      "system": "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes"
+      "system": "http://medizininformatik-initiative.de/fhir/CodeSystem/ecrf-parameter-codes"
     },
     "termCodeSearchParameter": "code",
     "valueSearchParameter": "value-quantity"

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-1-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-1-bundle.xml
@@ -177,7 +177,7 @@
                     <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
-                <name value="Netzwerk Universitätsmedizin"/>
+                <name value="Medizininformatik Initiative"/>
             </Organization>
         </resource>
         <request>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-1-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-1-bundle.xml
@@ -174,7 +174,7 @@
                 </meta>
                 <identifier>
                     <system value="http://highmed.org/sid/organization-identifier"/>
-                    <value value="netzwerk-universitaetsmedizin.de"/>
+                    <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
                 <name value="Netzwerk Universitätsmedizin"/>
@@ -184,7 +184,7 @@
             <method value="POST"/>
             <url value="Organization"/>
             <ifNoneExist
-                    value="identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de"/>
+                    value="identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de"/>
         </request>
     </entry>
 
@@ -224,7 +224,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
         </request>
     </entry>
 
@@ -264,7 +264,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_1"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_1"/>
         </request>
     </entry>
 </Bundle>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-2-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-2-bundle.xml
@@ -176,7 +176,7 @@
                 </meta>
                 <identifier>
                     <system value="http://highmed.org/sid/organization-identifier"/>
-                    <value value="netzwerk-universitaetsmedizin.de"/>
+                    <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
                 <name value="Netzwerk Universitätsmedizin"/>
@@ -186,7 +186,7 @@
             <method value="POST"/>
             <url value="Organization"/>
             <ifNoneExist
-                    value="identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de"/>
+                    value="identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de"/>
         </request>
     </entry>
 
@@ -226,7 +226,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
         </request>
     </entry>
 
@@ -266,7 +266,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_2"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_2"/>
         </request>
     </entry>
 </Bundle>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-2-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-2-bundle.xml
@@ -179,7 +179,7 @@
                     <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
-                <name value="Netzwerk Universitätsmedizin"/>
+                <name value="Medizininformatik Initiative"/>
             </Organization>
         </resource>
         <request>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-3-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-3-bundle.xml
@@ -179,7 +179,7 @@
                     <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
-                <name value="Netzwerk Universitätsmedizin"/>
+                <name value="Medizininformatik Initiative"/>
             </Organization>
         </resource>
         <request>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-3-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/dic-3-bundle.xml
@@ -176,7 +176,7 @@
                 </meta>
                 <identifier>
                     <system value="http://highmed.org/sid/organization-identifier"/>
-                    <value value="netzwerk-universitaetsmedizin.de"/>
+                    <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
                 <name value="Netzwerk Universitätsmedizin"/>
@@ -186,7 +186,7 @@
             <method value="POST"/>
             <url value="Organization"/>
             <ifNoneExist
-                    value="identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de"/>
+                    value="identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de"/>
         </request>
     </entry>
 
@@ -226,7 +226,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
         </request>
     </entry>
 
@@ -266,7 +266,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_3"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_3"/>
         </request>
     </entry>
 </Bundle>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/zars-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/zars-bundle.xml
@@ -341,7 +341,7 @@
                     <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
-                <name value="Netzwerk Universitätsmedizin"/>
+                <name value="Medizininformatik Initiative"/>
             </Organization>
         </resource>
         <request>

--- a/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/zars-bundle.xml
+++ b/feasibility-dsf-process-tools/feasibility-dsf-process-test-data-generator/src/main/resources/bundle-templates/zars-bundle.xml
@@ -338,7 +338,7 @@
                 </meta>
                 <identifier>
                     <system value="http://highmed.org/sid/organization-identifier"/>
-                    <value value="netzwerk-universitaetsmedizin.de"/>
+                    <value value="medizininformatik-initiative.de"/>
                 </identifier>
                 <active value="true"/>
                 <name value="Netzwerk Universitätsmedizin"/>
@@ -348,7 +348,7 @@
             <method value="POST"/>
             <url value="Organization"/>
             <ifNoneExist
-                    value="identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de"/>
+                    value="identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de"/>
         </request>
     </entry>
     <entry>
@@ -387,7 +387,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_ZARS"/>
         </request>
     </entry>
 
@@ -427,7 +427,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_1"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_1"/>
         </request>
     </entry>
 
@@ -467,7 +467,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_2"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_2"/>
         </request>
     </entry>
 
@@ -507,7 +507,7 @@
             <method value="POST"/>
             <url value="OrganizationAffiliation"/>
             <ifNoneExist
-                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|netzwerk-universitaetsmedizin.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_3"/>
+                    value="primary-organization:identifier=http://highmed.org/sid/organization-identifier|medizininformatik-initiative.de&amp;participating-organization:identifier=http://highmed.org/sid/organization-identifier|Test_DIC_3"/>
         </request>
     </entry>
 </Bundle>

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDefinition.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDefinition.java
@@ -27,7 +27,7 @@ public class FeasibilityProcessPluginDefinition implements ProcessPluginDefiniti
 
     @Override
     public String getName() {
-        return "feasibility-dsf-process";
+        return "mii-process-feasibility";
     }
 
     @Override
@@ -75,9 +75,9 @@ public class FeasibilityProcessPluginDefinition implements ProcessPluginDefiniti
         var vF = ValueSetResource.file("fhir/ValueSet/feasibility.xml");
 
         Map<String, List<AbstractResource>> resourcesByProcessKeyAndVersion = Map.of(
-                "wwwnetzwerk-universitaetsmedizinde_executeSimpleFeasibility/" + VERSION,
+                "medizininformatik-initiativede_executeSimpleFeasibility/" + VERSION,
                 Arrays.asList(aExe, sTExe, sTResS, vF, cF, sMeasure, sMeasureReport, sLibrary),
-                "wwwnetzwerk-universitaetsmedizinde_requestSimpleFeasibility/" + VERSION,
+                "medizininformatik-initiativede_requestSimpleFeasibility/" + VERSION,
                 Arrays.asList(aReq, sTReq, sExtDic, vF, cF, sMeasure, sMeasureReport, sLibrary));
 
         return ResourceProvider.read(VERSION,

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/variables/ConstantsFeasibility.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/variables/ConstantsFeasibility.java
@@ -10,11 +10,11 @@ public interface ConstantsFeasibility {
     String VARIABLE_EVALUATION_STRATEGY = "evaluation-strategy";
     String VARIABLE_EVALUATION_OBFUSCATION = "evaluation-obfuscation";
 
-    String CODESYSTEM_FEASIBILITY = "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility";
+    String CODESYSTEM_FEASIBILITY = "http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility";
     String CODESYSTEM_FEASIBILITY_VALUE_MEASURE_REFERENCE = "measure-reference";
     String CODESYSTEM_FEASIBILITY_VALUE_MEASURE_REPORT_REFERENCE = "measure-report-reference";
     String CODESYSTEM_MEASURE_POPULATION = "http://terminology.hl7.org/CodeSystem/measure-population";
     String CODESYSTEM_MEASURE_POPULATION_VALUE_INITIAL_POPULATION = "initial-population";
 
-    String EXTENSION_DIC_URI = "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/dic";
+    String EXTENSION_DIC_URI = "http://medizininformatik-initiative.de/fhir/StructureDefinition/dic";
 }

--- a/feasibility-dsf-process/src/main/resources/bpe/executeSimpleFeasibility.bpmn
+++ b/feasibility-dsf-process/src/main/resources/bpe/executeSimpleFeasibility.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0drkcb5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
-  <bpmn:process id="wwwnetzwerk-universitaetsmedizinde_executeSimpleFeasibility" isExecutable="true" camunda:versionTag="0.2.0">
+  <bpmn:process id="medizininformatik-initiativede_executeSimpleFeasibility" isExecutable="true" camunda:versionTag="0.2.0">
     <bpmn:startEvent id="StartEvent" name="start">
       <bpmn:outgoing>SequenceFlow_14cn0vs</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0sjtzj6" messageRef="Message_1yz2a31" />
@@ -14,8 +14,8 @@
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="messageName">resultSingleDicSimpleFeasibilityMessage</camunda:inputParameter>
-          <camunda:inputParameter name="instantiatesUri">http://www.netzwerk-universitaetsmedizin.de/bpe/Process/requestSimpleFeasibility/0.2.0</camunda:inputParameter>
-          <camunda:inputParameter name="profile">https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility|0.2.0</camunda:inputParameter>
+          <camunda:inputParameter name="instantiatesUri">http://medizininformatik-initiative.de/bpe/Process/requestSimpleFeasibility/0.2.0</camunda:inputParameter>
+          <camunda:inputParameter name="profile">http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility|0.2.0</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0ascyjc</bpmn:incoming>
@@ -85,7 +85,7 @@
   <bpmn:message id="Message_1yz2a31" name="executeSimpleFeasibilityMessage" />
   <bpmn:message id="Message_1dr71re" name="resultSingleDicSimpleFeasibilityMessage" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wwwnetzwerk-universitaetsmedizinde_executeSimpleFeasibility">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="medizininformatik-initiativede_executeSimpleFeasibility">
       <bpmndi:BPMNEdge id="Flow_10dmu4o_di" bpmnElement="Flow_10dmu4o">
         <di:waypoint x="1050" y="160" />
         <di:waypoint x="1050" y="250" />

--- a/feasibility-dsf-process/src/main/resources/bpe/requestSimpleFeasibility.bpmn
+++ b/feasibility-dsf-process/src/main/resources/bpe/requestSimpleFeasibility.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0inb4ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
-  <bpmn:process id="wwwnetzwerk-universitaetsmedizinde_requestSimpleFeasibility" name="storeResult" isExecutable="true" camunda:versionTag="0.2.0">
+  <bpmn:process id="medizininformatik-initiativede_requestSimpleFeasibility" name="storeResult" isExecutable="true" camunda:versionTag="0.2.0">
     <bpmn:startEvent id="StartEvent" name="start">
       <bpmn:outgoing>SequenceFlow_11k77gx</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_10c2suu" messageRef="Message_1pq9qxp" />
@@ -12,9 +12,9 @@
     <bpmn:sendTask id="sendRequestToDics" name="send request to dics" camunda:class="de.medizininformatik_initiative.feasibility_dsf_process.message.SendDicRequest">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="instantiatesUri">http://www.netzwerk-universitaetsmedizin.de/bpe/Process/executeSimpleFeasibility/0.2.0</camunda:inputParameter>
+          <camunda:inputParameter name="instantiatesUri">http://medizininformatik-initiative.de/bpe/Process/executeSimpleFeasibility/0.2.0</camunda:inputParameter>
           <camunda:inputParameter name="messageName">executeSimpleFeasibilityMessage</camunda:inputParameter>
-          <camunda:inputParameter name="profile">https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-execute-simple-feasibility|0.2.0</camunda:inputParameter>
+          <camunda:inputParameter name="profile">http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-execute-simple-feasibility|0.2.0</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0b5s4ef</bpmn:incoming>
@@ -94,7 +94,7 @@
   <bpmn:message id="Message_1vrxfsk" name="resultMultiMedicSimpleFeasibilityMessage" />
   <bpmn:message id="Message_18ld88c" name="resultSingleDicSimpleFeasibilityMessage" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wwwnetzwerk-universitaetsmedizinde_requestSimpleFeasibility">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="medizininformatik-initiativede_requestSimpleFeasibility">
       <bpmndi:BPMNEdge id="Flow_1f790pw_di" bpmnElement="Flow_1f790pw">
         <di:waypoint x="1560" y="155" />
         <di:waypoint x="1612" y="155" />

--- a/feasibility-dsf-process/src/main/resources/fhir/ActivityDefinition/executeSimpleFeasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/ActivityDefinition/executeSimpleFeasibility.xml
@@ -11,7 +11,7 @@
         </extension>
         <extension url="task-profile">
             <valueCanonical
-                    value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-execute-simple-feasibility|${version}"/>
+                    value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-execute-simple-feasibility|${version}"/>
         </extension>
         <extension url="requester">
             <valueCoding>
@@ -20,7 +20,7 @@
                     <extension url="consortium">
                         <valueIdentifier>
                             <system value="http://highmed.org/sid/organization-identifier"/>
-                            <value value="netzwerk-universitaetsmedizin.de"/>
+                            <value value="medizininformatik-initiative.de"/>
                         </valueIdentifier>
                     </extension>
                     <extension url="role">
@@ -41,7 +41,7 @@
                     <extension url="consortium">
                         <valueIdentifier>
                             <system value="http://highmed.org/sid/organization-identifier"/>
-                            <value value="netzwerk-universitaetsmedizin.de"/>
+                            <value value="medizininformatik-initiative.de"/>
                         </valueIdentifier>
                     </extension>
                     <extension url="role">
@@ -56,7 +56,7 @@
             </valueCoding>
         </extension>
     </extension>
-    <url value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/executeSimpleFeasibility"/>
+    <url value="http://medizininformatik-initiative.de/bpe/Process/executeSimpleFeasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="ExecuteSimpleFeasibility"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/ActivityDefinition/requestSimpleFeasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/ActivityDefinition/requestSimpleFeasibility.xml
@@ -11,7 +11,7 @@
         </extension>
         <extension url="task-profile">
             <valueCanonical
-                    value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-request-simple-feasibility|${version}"/>
+                    value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-request-simple-feasibility|${version}"/>
         </extension>
         <extension url="requester">
             <valueCoding>
@@ -20,7 +20,7 @@
                     <extension url="consortium">
                         <valueIdentifier>
                             <system value="http://highmed.org/sid/organization-identifier"/>
-                            <value value="netzwerk-universitaetsmedizin.de"/>
+                            <value value="medizininformatik-initiative.de"/>
                         </valueIdentifier>
                     </extension>
                     <extension url="role">
@@ -41,7 +41,7 @@
                     <extension url="consortium">
                         <valueIdentifier>
                             <system value="http://highmed.org/sid/organization-identifier"/>
-                            <value value="netzwerk-universitaetsmedizin.de"/>
+                            <value value="medizininformatik-initiative.de"/>
                         </valueIdentifier>
                     </extension>
                     <extension url="role">
@@ -62,7 +62,7 @@
         </extension>
         <extension url="task-profile">
             <valueCanonical
-                    value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility|${version}"/>
+                    value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility|${version}"/>
         </extension>
         <extension url="requester">
             <valueCoding>
@@ -71,7 +71,7 @@
                     <extension url="consortium">
                         <valueIdentifier>
                             <system value="http://highmed.org/sid/organization-identifier"/>
-                            <value value="netzwerk-universitaetsmedizin.de"/>
+                            <value value="medizininformatik-initiative.de"/>
                         </valueIdentifier>
                     </extension>
                     <extension url="role">
@@ -92,7 +92,7 @@
                     <extension url="consortium">
                         <valueIdentifier>
                             <system value="http://highmed.org/sid/organization-identifier"/>
-                            <value value="netzwerk-universitaetsmedizin.de"/>
+                            <value value="medizininformatik-initiative.de"/>
                         </valueIdentifier>
                     </extension>
                     <extension url="role">
@@ -107,7 +107,7 @@
             </valueCoding>
         </extension>
     </extension>
-    <url value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/requestSimpleFeasibility"/>
+    <url value="http://medizininformatik-initiative.de/bpe/Process/requestSimpleFeasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="RequestSimpleFeasibility"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/CodeSystem/feasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/CodeSystem/feasibility.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility"/>
+    <url value="http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="Codex_Feasibility"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-extension-dic.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-extension-dic.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/dic"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/dic"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="Dic"/>
@@ -31,7 +31,7 @@
         </element>
         <element id="Extension.url">
             <path value="Extension.url"/>
-            <fixedUri value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/dic"/>
+            <fixedUri value="http://medizininformatik-initiative.de/fhir/StructureDefinition/dic"/>
         </element>
         <element id="Extension.value[x]">
             <path value="Extension.value[x]"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-library.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-library.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-library"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-library"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="Library"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-measure-report.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-measure-report.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-measure-report"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-measure-report"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="MeasureReport"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-measure.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-measure.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-measure"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-measure"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="Measure"/>
@@ -37,7 +37,7 @@
             <type>
                 <code value="canonical"/>
                 <targetProfile
-                        value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-library"/>
+                        value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-library"/>
             </type>
             <mustSupport value="true"/>
         </element>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-task-execute-simple-feasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-task-execute-simple-feasibility.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-execute-simple-feasibility"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-execute-simple-feasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="TaskExecuteSimpleFeasibility"/>
@@ -22,7 +22,7 @@
     <differential>
         <element id="Task.instantiatesUri">
             <path value="Task.instantiatesUri"/>
-            <fixedUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/executeSimpleFeasibility/${version}"/>
+            <fixedUri value="http://medizininformatik-initiative.de/bpe/Process/executeSimpleFeasibility/${version}"/>
         </element>
         <element id="Task.input">
             <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
@@ -75,7 +75,7 @@
                     <valueString value="TaskInputParameterType"/>
                 </extension>
                 <strength value="required"/>
-                <valueSet value="https://www.netzwerk-universitaetsmedizin.de/fhir/ValueSet/feasibility"/>
+                <valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/feasibility"/>
             </binding>
         </element>
         <element id="Task.input:measure.type.coding">
@@ -86,7 +86,7 @@
         <element id="Task.input:measure.type.coding.system">
             <path value="Task.input.type.coding.system"/>
             <min value="1"/>
-            <fixedUri value="https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility"/>
+            <fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility"/>
         </element>
         <element id="Task.input:measure.type.coding.code">
             <path value="Task.input.type.coding.code"/>
@@ -97,7 +97,7 @@
             <path value="Task.input.value[x]"/>
             <type>
                 <code value="Reference"/>
-                <targetProfile value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-measure"/>
+                <targetProfile value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-measure"/>
             </type>
         </element>
     </differential>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-task-request-simple-feasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-task-request-simple-feasibility.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-request-simple-feasibility"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-request-simple-feasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="TaskRequestSimpleFeasibility"/>
@@ -22,7 +22,7 @@
     <differential>
         <element id="Task.instantiatesUri">
             <path value="Task.instantiatesUri"/>
-            <fixedUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/requestSimpleFeasibility/${version}"/>
+            <fixedUri value="http://medizininformatik-initiative.de/bpe/Process/requestSimpleFeasibility/${version}"/>
         </element>
         <element id="Task.input">
             <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
@@ -75,7 +75,7 @@
                     <valueString value="TaskInputParameterType"/>
                 </extension>
                 <strength value="required"/>
-                <valueSet value="https://www.netzwerk-universitaetsmedizin.de/fhir/ValueSet/feasibility"/>
+                <valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/feasibility"/>
             </binding>
         </element>
         <element id="Task.input:measure.type.coding">
@@ -86,7 +86,7 @@
         <element id="Task.input:measure.type.coding.system">
             <path value="Task.input.type.coding.system"/>
             <min value="1"/>
-            <fixedUri value="https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility"/>
+            <fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility"/>
         </element>
         <element id="Task.input:measure.type.coding.code">
             <path value="Task.input.type.coding.code"/>
@@ -98,7 +98,7 @@
             <type>
                 <code value="Reference"/>
                 <targetProfile
-                        value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-measure"/>
+                        value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-measure"/>
             </type>
         </element>
         <element id="Task.output">
@@ -123,7 +123,7 @@
                     <valueString value="TaskInputParameterType"/>
                 </extension>
                 <strength value="required"/>
-                <valueSet value="https://www.netzwerk-universitaetsmedizin.de/fhir/ValueSet/feasibility"/>
+                <valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/feasibility"/>
             </binding>
         </element>
         <element id="Task.output:measure-report.type.coding">
@@ -134,7 +134,7 @@
         <element id="Task.output:measure-report.type.coding.system">
             <path value="Task.output.type.coding.system"/>
             <min value="1"/>
-            <fixedUri value="https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility"/>
+            <fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility"/>
         </element>
         <element id="Task.output:measure-report.type.coding.code">
             <path value="Task.output.type.coding.code"/>

--- a/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-task-single-dic-result-simple-feasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/StructureDefinition/feasibility-task-single-dic-result-simple-feasibility.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility"/>
+    <url value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="TaskSingleDicResultSimpleFeasibility"/>
@@ -22,7 +22,7 @@
     <differential>
         <element id="Task.instantiatesUri">
             <path value="Task.instantiatesUri"/>
-            <fixedUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/requestSimpleFeasibility/${version}"/>
+            <fixedUri value="http://medizininformatik-initiative.de/bpe/Process/requestSimpleFeasibility/${version}"/>
         </element>
         <element id="Task.input">
             <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
@@ -75,7 +75,7 @@
                     <valueString value="TaskInputParameterType"/>
                 </extension>
                 <strength value="required"/>
-                <valueSet value="https://www.netzwerk-universitaetsmedizin.de/fhir/ValueSet/feasibility"/>
+                <valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/feasibility"/>
             </binding>
         </element>
         <element id="Task.input:measure-report.type.coding">
@@ -86,7 +86,7 @@
         <element id="Task.input:measure-report.type.coding.system">
             <path value="Task.input.type.coding.system"/>
             <min value="1"/>
-            <fixedUri value="https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility"/>
+            <fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility"/>
         </element>
         <element id="Task.input:measure-report.type.coding.code">
             <path value="Task.input.type.coding.code"/>
@@ -98,7 +98,7 @@
             <type>
                 <code value="Reference"/>
                 <targetProfile
-                        value="https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-measure-report"/>
+                        value="http://medizininformatik-initiative.de/fhir/StructureDefinition/codex-measure-report"/>
             </type>
         </element>
         <element id="Task.input:measure-report.value[x].reference">

--- a/feasibility-dsf-process/src/main/resources/fhir/ValueSet/feasibility.xml
+++ b/feasibility-dsf-process/src/main/resources/fhir/ValueSet/feasibility.xml
@@ -5,7 +5,7 @@
             <code value="ALL"/>
         </tag>
     </meta>
-    <url value="https://www.netzwerk-universitaetsmedizin.de/fhir/ValueSet/feasibility"/>
+    <url value="http://medizininformatik-initiative.de/fhir/ValueSet/feasibility"/>
     <!-- version managed by bpe -->
     <version value="${version}"/>
     <name value="Codex_Feasibility"/>
@@ -19,7 +19,7 @@
     <immutable value="true"/>
     <compose>
         <include>
-            <system value="https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility"/>
+            <system value="http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility"/>
         </include>
     </compose>
 </ValueSet>


### PR DESCRIPTION
Moves any namespace related mentions to MII.
Specifically, `www.netzwerk-universitaetsmedizin.de` is moved to `medizininformatik-initiative.de`.

**This is a breaking change** since tasks sent by a client need to be updated (`instantiateUri`, `receiver` etc.)