### PR TITLE
Switch to Obfuscation Set in Project Contract

### DIFF
--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityCountObfuscator.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityCountObfuscator.java
@@ -1,17 +1,57 @@
 package de.medizininformatik_initiative.feasibility_dsf_process;
 
+import java.util.Random;
+
+import static java.util.Objects.requireNonNull;
+
 /**
  * Obfuscator for obfuscating feasibility counts.
  */
-public class FeasibilityCountObfuscator {
+public class FeasibilityCountObfuscator implements Obfuscator<Integer> {
+
+    private static final Integer MAX_RANDOM_OBFUSCATOR_VALUE = 10;
+
+    // Obfuscated feasibility counts less than this value get discarded by setting
+    // the obfuscation result to 0.
+    private static final Integer MIN_ALLOWED_OBFUSCATED_RESULT = 5;
+
+    // We can't use RandomGenerator of Java 17 since this plugin will run within a framework still
+    // using Java 11 and is built for this version. Thus, using a lightweight wrapper should be fine.
+    private final RandomNumberGenerator randomGenerator;
+
+    public FeasibilityCountObfuscator(RandomNumberGenerator randomGenerator) {
+        this.randomGenerator = requireNonNull(randomGenerator, "random number generator must not be null");
+    }
 
     /**
-     * Obfuscates the given feasibility count by calculating the same count rounded to the nearest ten.
+     * Obfuscates the given feasibility count by randomly adding a value in the range of [-5, 5] to it.
+     * <p>
+     * Important:
+     * <b>Returns 0, should the obfuscated result be less than 5.</b>
+     * </p>
      *
      * @param feasibilityCount The feasibility count that shall be obfuscated.
      * @return The obfuscated feasibility count.
      */
-    public int obfuscate(int feasibilityCount) {
-        return feasibilityCount - (feasibilityCount % 10) + 10;
+    public Integer obfuscate(Integer feasibilityCount) {
+        var obfuscationOffset = randomGenerator.generateRandomNumber(MAX_RANDOM_OBFUSCATOR_VALUE + 1)
+                - (MAX_RANDOM_OBFUSCATOR_VALUE / 2);
+
+        var obfuscatedFeasibilityCount = feasibilityCount + obfuscationOffset;
+        return (obfuscatedFeasibilityCount < MIN_ALLOWED_OBFUSCATED_RESULT) ? 0 : obfuscatedFeasibilityCount;
+    }
+
+    public static class ObfuscationRandomNumberGenerator implements RandomNumberGenerator {
+
+        private final Random random;
+
+        public ObfuscationRandomNumberGenerator() {
+            random = new Random();
+        }
+
+        @Override
+        public int generateRandomNumber(int bound) {
+            return random.nextInt(bound);
+        }
     }
 }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/Obfuscator.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/Obfuscator.java
@@ -1,0 +1,17 @@
+package de.medizininformatik_initiative.feasibility_dsf_process;
+
+/**
+ * Describes how values of a type T can get obfuscated.
+ *
+ * @param <T> The type of the value that shall get obfuscated.
+ */
+public interface Obfuscator<T> {
+
+    /**
+     * Obfuscates the specified value and returns the result.
+     *
+     * @param value Gets obfuscated.
+     * @return The obfuscated value.
+     */
+    T obfuscate(T value);
+}

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/RandomNumberGenerator.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/RandomNumberGenerator.java
@@ -1,0 +1,15 @@
+package de.medizininformatik_initiative.feasibility_dsf_process;
+
+/**
+ * Describes a simple random number generator.
+ */
+public interface RandomNumberGenerator {
+
+    /**
+     * Returns a pseudorandom, uniformly distributed int value between 0 (inclusive) and the specified value (exclusive).
+     *
+     * @param bound The upper bound (must be positive).
+     * @return A pseudorandom, uniformly distributed int value between zero (inclusive) and bound (exclusive)
+     */
+    int generateRandomNumber(int bound);
+}

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/ObfuscateEvaluationResult.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/service/ObfuscateEvaluationResult.java
@@ -1,6 +1,6 @@
 package de.medizininformatik_initiative.feasibility_dsf_process.service;
 
-import de.medizininformatik_initiative.feasibility_dsf_process.FeasibilityCountObfuscator;
+import de.medizininformatik_initiative.feasibility_dsf_process.Obfuscator;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.highmed.dsf.bpe.delegate.AbstractServiceDelegate;
 import org.highmed.dsf.fhir.authorization.read.ReadAccessHelper;
@@ -15,10 +15,10 @@ import static de.medizininformatik_initiative.feasibility_dsf_process.variables.
 
 public class ObfuscateEvaluationResult extends AbstractServiceDelegate implements InitializingBean {
 
-    private final FeasibilityCountObfuscator obfuscator;
+    private final Obfuscator<Integer> obfuscator;
 
     public ObfuscateEvaluationResult(FhirWebserviceClientProvider clientProvider, TaskHelper taskHelper,
-                                     ReadAccessHelper readAccessHelper, FeasibilityCountObfuscator obfuscator) {
+                                     ReadAccessHelper readAccessHelper, Obfuscator<Integer> obfuscator) {
         super(clientProvider, taskHelper, readAccessHelper);
         this.obfuscator = obfuscator;
     }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/spring/config/FeasibilityConfig.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/spring/config/FeasibilityConfig.java
@@ -9,19 +9,7 @@ import de.medizininformatik_initiative.feasibility_dsf_process.FeasibilityCountO
 import de.medizininformatik_initiative.feasibility_dsf_process.client.flare.FlareWebserviceClient;
 import de.medizininformatik_initiative.feasibility_dsf_process.message.SendDicRequest;
 import de.medizininformatik_initiative.feasibility_dsf_process.message.SendDicResponse;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.AggregateMeasureReports;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.DownloadFeasibilityResources;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.DownloadMeasureReport;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.EvaluateCqlMeasure;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.EvaluateStructuredQueryMeasure;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.ObfuscateEvaluationResult;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.PrepareForFurtherEvaluation;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.SelectRequestTargets;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.SelectResponseTarget;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.SetupEvaluationSettings;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.StoreFeasibilityResources;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.StoreLiveResult;
-import de.medizininformatik_initiative.feasibility_dsf_process.service.StoreMeasureReport;
+import de.medizininformatik_initiative.feasibility_dsf_process.service.*;
 import org.highmed.dsf.fhir.authorization.read.ReadAccessHelper;
 import org.highmed.dsf.fhir.client.FhirWebserviceClientProvider;
 import org.highmed.dsf.fhir.organization.EndpointProvider;
@@ -71,7 +59,8 @@ public class FeasibilityConfig {
 
     @Bean
     public FeasibilityCountObfuscator feasibilityCountObfuscator() {
-        return new FeasibilityCountObfuscator();
+        var randomNumberGenerator = new FeasibilityCountObfuscator.ObfuscationRandomNumberGenerator();
+        return new FeasibilityCountObfuscator(randomNumberGenerator);
     }
 
     //

--- a/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityCountObfuscatorTest.java
+++ b/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityCountObfuscatorTest.java
@@ -1,44 +1,50 @@
 package de.medizininformatik_initiative.feasibility_dsf_process;
 
-import de.medizininformatik_initiative.feasibility_dsf_process.FeasibilityCountObfuscator;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
+@RunWith(MockitoJUnitRunner.class)
 public class FeasibilityCountObfuscatorTest {
 
-    private FeasibilityCountObfuscator obfuscator;
+    @Mock
+    private RandomNumberGenerator randomNumberGenerator;
 
-    @Before
-    public void setUp() {
-        obfuscator = new FeasibilityCountObfuscator();
-    }
-
-    @Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {0, 10}, {5, 10}, {10, 20}, {20, 30}, {100, 110}, {113, 120}
-        });
-    }
-
-    @Parameter
-    public int feasibilityCount;
-
-    @Parameter(1)
-    public int expectedObfuscatedFeasibilityCount;
-
+    @InjectMocks
+    private FeasibilityCountObfuscator feasibilityCountObfuscator;
 
     @Test
-    public void testObfuscateFeasibility() {
-        assertEquals(expectedObfuscatedFeasibilityCount, obfuscator.obfuscate(feasibilityCount));
+    public void testObfuscateFeasibility_ObfuscatedResultsLowerThanFiveGetReturnedAsZero() {
+        when(randomNumberGenerator.generateRandomNumber(anyInt())).thenReturn(1, 2, 3, 4);
+
+        int nonObfuscatedFeasibilityResult = 5;
+        List<Integer> obfuscatedFeasibilityResults = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            obfuscatedFeasibilityResults.add(feasibilityCountObfuscator.obfuscate(nonObfuscatedFeasibilityResult));
+        }
+
+        assertIterableEquals(List.of(0, 0, 0, 0), obfuscatedFeasibilityResults);
+    }
+
+    @Test
+    public void testObfuscateFeasibility_ObfustedResultsGreaterOrEqualToFiveAreKept() {
+        when(randomNumberGenerator.generateRandomNumber(anyInt())).thenReturn(0, 5, 10);
+
+        int nonObfuscatedFeasibilityResult = 10;
+        List<Integer> obfuscatedFeasibilityResults = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            obfuscatedFeasibilityResults.add(feasibilityCountObfuscator.obfuscate(nonObfuscatedFeasibilityResult));
+        }
+
+        assertIterableEquals(List.of(5, 10, 15), obfuscatedFeasibilityResults);
     }
 }


### PR DESCRIPTION
Drops the current obfuscation implementation for feasibility
counts. Uses a new obfuscation implementation so that a random
number within the range [-5,5] gets added to the actual
feasibility count.

Additionally, ensures that obfuscation results less than 5 get
"discarded" by setting them to zero instead.

Resolves #22 