### PR TITLE
Remove Existing Keystore Before Generation

### DIFF
--- a/feasibility-dsf-process-docker-test-setup/rebuild.sh
+++ b/feasibility-dsf-process-docker-test-setup/rebuild.sh
@@ -13,6 +13,7 @@ openssl req -x509 -sha256 -days 365 -nodes -newkey rsa:2048 -keyout ${BASE_DIR}/
 # Convert certificate to PKCS12 format
 # This is done using keytool instead of openssl since keytool adds a proprietary attribute that openssl does not.
 # Without this attribute Java cannot properly process the resulting P12 file.
+rm -f ${BASE_DIR}/secrets/dic_3_store_proxy_self_signed_ca.p12
 keytool -genkeypair -alias tmp -storepass testpw \
   -keystore ${BASE_DIR}/secrets/dic_3_store_proxy_self_signed_ca.p12 \
   -dname "CN=tmp, OU=tmp, O=tmp, L=tmp, ST=tmp, C=tmp"


### PR DESCRIPTION
This ensures that the keystore contains up-to-date information even if there has been a previous version of it. Without this change the keystore would not get updated when running the rebuild.sh script multiple times. Depending on how much time has passed during script invocations this could lead to runtime issues since certificates may no longer be valid.

Fixes #32 