### PR TITLE
Adjust Dependency Config for DIC 3 BPE Test Setup

### DIFF
--- a/feasibility-dsf-process-docker-test-setup/docker-compose.yml
+++ b/feasibility-dsf-process-docker-test-setup/docker-compose.yml
@@ -591,8 +591,8 @@ services:
       internet:
     depends_on:
       - db
+      - dic-3-fhir-app
       - dedicated-dic-3-store-proxy
-      - proxy
 
   # ---- DIC-3 - DEDICATED PROXY WITH SELF SIGNED CERT ------------------------
   dedicated-dic-3-store-proxy:


### PR DESCRIPTION
Ensures that the corresponding FHIR part gets started when trying to start the BPE part. This is important since the FHIR part needs to run in order to successfully start the BPE part.

Fixes #33 