### PR TITLE
Decrease timeout of overall BPE process to 45s

### DIFF
--- a/feasibility-dsf-process/src/main/resources/bpe/feasibilityRequest.bpmn
+++ b/feasibility-dsf-process/src/main/resources/bpe/feasibilityRequest.bpmn
@@ -67,7 +67,7 @@
     <bpmn:boundaryEvent id="Event_13wq5pb" attachedToRef="Activity_1h2vwsh">
       <bpmn:outgoing>Flow_1479yc4</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0bvcu02">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5M</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT45S</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_0qqdr67" sourceRef="sendRequestToDics" targetRef="Activity_1h2vwsh" />


### PR DESCRIPTION
Intermediate updates of a Task resource in the BPE are synchronized to the FHIR store only when the task status changes (e. g., `request` -> `in-progress`, `in-progress` -> `completed`). We need a different approach to propagate results back to the feasibility gui backend immediately.

For a quick workaround this change decreases the overall timeout of the parallel dic requests from 5 minutes to 45 seconds in order to fulfil the 1 minute response requirement.