### PR TITLE
Enable Parameter Name Information for Compiled Classes

### DIFF
--- a/feasibility-dsf-process/pom.xml
+++ b/feasibility-dsf-process/pom.xml
@@ -128,6 +128,16 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Avoid warning message about falling back to debug compilation mode.

Closes #67 