### PR TITLE
Check Connection to Store or Flare on Startup

### DIFF
--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDefinition.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDefinition.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.FEASIBILITY_EXECUTE_PROCESS_ID;
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.FEASIBILITY_REQUEST_PROCESS_ID;
 
 public class FeasibilityProcessPluginDefinition implements ProcessPluginDefinition {
 
@@ -84,9 +86,9 @@ public class FeasibilityProcessPluginDefinition implements ProcessPluginDefiniti
         var vF = "fhir/ValueSet/feasibility.xml";
 
         return Map.of(
-                "medizininformatik-initiativede_feasibilityExecute",
+                FEASIBILITY_EXECUTE_PROCESS_ID,
                 Arrays.asList(aExe, sTExe, sTResS, vF, cF, sMeasure, sMeasureReport, sLibrary),
-                "medizininformatik-initiativede_feasibilityRequest",
+                FEASIBILITY_REQUEST_PROCESS_ID,
                 Arrays.asList(aReq, sTReq, sTResS, sExtDic, vF, cF, sMeasure, sMeasureReport, sLibrary));
     }
 }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDeploymentStateListener.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDeploymentStateListener.java
@@ -1,0 +1,70 @@
+package de.medizininformatik_initiative.feasibility_dsf_process;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import de.medizininformatik_initiative.feasibility_dsf_process.client.flare.FlareWebserviceClient;
+import dev.dsf.bpe.v1.ProcessPluginDeploymentStateListener;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+
+import java.io.IOException;
+import java.util.List;
+
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.FEASIBILITY_EXECUTE_PROCESS_ID;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * After process deployment starts a connection test if the <i>feasibilityExecute</i> process is active.
+ * <p>
+ * The configured {@link EvaluationStrategy} determines which client is used for the connection test.
+ * </p>
+ *
+ * @author <a href="mailto:math2306@hotmail.com">Mathias Rühle</a>
+ */
+public class FeasibilityProcessPluginDeploymentStateListener
+        implements ProcessPluginDeploymentStateListener, InitializingBean {
+
+    private static final Logger logger = LoggerFactory.getLogger(FeasibilityProcessPluginDeploymentStateListener.class);
+
+    private EvaluationStrategy strategy;
+    private IGenericClient storeClient;
+    private FlareWebserviceClient flareWebserviceClient;
+
+    public FeasibilityProcessPluginDeploymentStateListener(EvaluationStrategy strategy, IGenericClient storeClient,
+            FlareWebserviceClient flareWebserviceClient) {
+        this.strategy = strategy;
+        this.storeClient = storeClient;
+        this.flareWebserviceClient = flareWebserviceClient;
+    }
+
+    @Override
+    public void onProcessesDeployed(List<String> processes) {
+        if (processes.contains(FEASIBILITY_EXECUTE_PROCESS_ID)) {
+            if (strategy.equals(EvaluationStrategy.CQL)) {
+                try {
+                    CapabilityStatement statement = storeClient.capabilities().ofType(CapabilityStatement.class)
+                            .execute();
+                    logger.info("Connection test OK ({} - {})", statement.getSoftware().getName(),
+                            statement.getSoftware().getVersion());
+                } catch (RuntimeException e) {
+                    logger.warn("Connection test FAILED - error: {} - {}", e.getClass().getName(), e.getMessage());
+                }
+            } else {
+                try {
+                    flareWebserviceClient.testConnection();
+                    logger.info("Connection test OK (flare)");
+                } catch (IOException e) {
+                    logger.warn("Connection test FAILED (flare) - error: {} - {}", e.getClass().getName(),
+                            e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        requireNonNull(storeClient);
+        requireNonNull(flareWebserviceClient);
+    }
+}

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/client/flare/FlareWebserviceClient.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/client/flare/FlareWebserviceClient.java
@@ -1,5 +1,7 @@
 package de.medizininformatik_initiative.feasibility_dsf_process.client.flare;
 
+import org.apache.http.client.ClientProtocolException;
+
 import java.io.IOException;
 
 /**
@@ -17,4 +19,16 @@ public interface FlareWebserviceClient {
      * @throws InterruptedException If the operation is interrupted.
      */
     int requestFeasibility(byte[] structuredQuery) throws IOException, InterruptedException;
+
+    /**
+     * Tests the connection to the flare server, and flare server only, using the connection settings defined by spring
+     * configuration.
+     * <p>
+     * Throws an exception if the connection test fails, otherwise the connection test was successful.
+     * </p>
+     *
+     * @throws IOException in case of a problem or the connection was aborted
+     * @throws ClientProtocolException in case of an http protocol error
+     */
+    void testConnection() throws ClientProtocolException, IOException;
 }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/client/flare/FlareWebserviceClientImpl.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/client/flare/FlareWebserviceClientImpl.java
@@ -1,6 +1,8 @@
 package de.medizininformatik_initiative.feasibility_dsf_process.client.flare;
 
+import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
@@ -26,12 +28,23 @@ public class FlareWebserviceClientImpl implements FlareWebserviceClient {
 
     @Override
     public int requestFeasibility(byte[] structuredQuery) throws IOException, InterruptedException {
-        var req = new HttpPost(flareBaseUrl.resolve((flareBaseUrl.getPath() + "/query/execute").replaceAll("//", "/")));
+        var req = new HttpPost(resolve("/query/execute"));
         req.setEntity(new ByteArrayEntity(structuredQuery));
         req.setHeader(new BasicHeader(HEADER_CONTENT_TYPE, "application/sq+json"));
 
         var response = httpClient.execute(req, new BasicResponseHandler());
 
         return Integer.parseInt(response);
+    }
+
+    private URI resolve(String path) {
+        return flareBaseUrl.resolve((flareBaseUrl.getPath() + path).replaceAll("//", "/"));
+    }
+
+    @Override
+    public void testConnection() throws ClientProtocolException, IOException {
+        var req = new HttpGet(resolve("/cache/stats"));
+
+        httpClient.execute(req, new BasicResponseHandler());
     }
 }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/client/flare/FlareWebserviceClientSpringConfig.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/client/flare/FlareWebserviceClientSpringConfig.java
@@ -76,6 +76,10 @@ public class FlareWebserviceClientSpringConfig {
 
             @Override
             public int requestFeasibility(byte[] structuredQuery) throws IOException, InterruptedException {
+                return getClient().requestFeasibility(structuredQuery);
+            }
+
+            private FlareWebserviceClient getClient() {
                 if (client == null) {
                     checkArgument(!isNullOrEmpty(flareBaseUrl), "FLARE_BASE_URL is not set.");
                     try {
@@ -86,7 +90,12 @@ public class FlareWebserviceClientSpringConfig {
                                 format("Could not parse FLARE_BASE_URL '%s' as URI.", flareBaseUrl), e);
                     }
                 }
-                return client.requestFeasibility(structuredQuery);
+                return client;
+            }
+
+            @Override
+            public void testConnection() throws ClientProtocolException, IOException {
+                getClient().testConnection();
             }
         };
     }

--- a/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/variables/ConstantsFeasibility.java
+++ b/feasibility-dsf-process/src/main/java/de/medizininformatik_initiative/feasibility_dsf_process/variables/ConstantsFeasibility.java
@@ -20,4 +20,7 @@ public interface ConstantsFeasibility {
     String CODESYSTEM_MEASURE_POPULATION_VALUE_INITIAL_POPULATION = "initial-population";
 
     String EXTENSION_DIC_URI = "http://medizininformatik-initiative.de/fhir/StructureDefinition/dic";
+
+    String FEASIBILITY_REQUEST_PROCESS_ID = "medizininformatik-initiativede_feasibilityRequest";
+    String FEASIBILITY_EXECUTE_PROCESS_ID = "medizininformatik-initiativede_feasibilityExecute";
 }

--- a/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDeploymentStateListenerTest.java
+++ b/feasibility-dsf-process/src/test/java/de/medizininformatik_initiative/feasibility_dsf_process/FeasibilityProcessPluginDeploymentStateListenerTest.java
@@ -1,0 +1,146 @@
+package de.medizininformatik_initiative.feasibility_dsf_process;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IFetchConformanceTyped;
+import ca.uhn.fhir.rest.gclient.IFetchConformanceUntyped;
+import de.medizininformatik_initiative.feasibility_dsf_process.client.flare.FlareWebserviceClient;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementSoftwareComponent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.FEASIBILITY_EXECUTE_PROCESS_ID;
+import static de.medizininformatik_initiative.feasibility_dsf_process.variables.ConstantsFeasibility.FEASIBILITY_REQUEST_PROCESS_ID;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FeasibilityProcessPluginDeploymentStateListenerTest {
+
+    @Mock FlareWebserviceClient flareClient;
+    @Mock IGenericClient storeClient;
+    @Mock IFetchConformanceUntyped untypedFetch;
+    @Mock IFetchConformanceTyped<CapabilityStatement> typedFetch;
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @BeforeEach
+    void setup() {
+        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(err));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    @Test
+    @DisplayName("connection test is not executed when no process is deployed.")
+    void noConnectionTestIfNoProcessDeployed() throws Exception {
+        FeasibilityProcessPluginDeploymentStateListener listener = new FeasibilityProcessPluginDeploymentStateListener(
+                EvaluationStrategy.CQL, storeClient, flareClient);
+
+        listener.onProcessesDeployed(List.of());
+
+        verify(flareClient, never()).requestFeasibility(any(byte[].class));
+    }
+
+    @Test
+    @DisplayName("connection test is not executed when 'feasibilityExecute' process is not deployed.")
+    void noConnectionTestIfExecuteProcessIsNotDeployed() throws Exception {
+        FeasibilityProcessPluginDeploymentStateListener listener = new FeasibilityProcessPluginDeploymentStateListener(
+                EvaluationStrategy.CQL, storeClient, flareClient);
+
+        listener.onProcessesDeployed(List.of("foo", FEASIBILITY_REQUEST_PROCESS_ID, "bar"));
+
+        verify(flareClient, never()).requestFeasibility(any(byte[].class));
+    }
+
+    @Test
+    @DisplayName("flare client connection test succeeds when evaluation strategy is 'structured-query' and no error occurs")
+    void flareClientConnectionTestSucceeds() throws Exception {
+
+            FeasibilityProcessPluginDeploymentStateListener listener = new FeasibilityProcessPluginDeploymentStateListener(
+                    EvaluationStrategy.STRUCTURED_QUERY, storeClient, flareClient);
+
+            listener.onProcessesDeployed(List.of(FEASIBILITY_EXECUTE_PROCESS_ID));
+
+            verify(flareClient).testConnection();
+            assertThat(out.toString(), containsString("Connection test OK (flare)"));
+    }
+
+    @Test
+    @DisplayName("store client connection test succeeds when evaluation strategy is 'cql' and no error occurs")
+    void storeClientConnectionTestSucceeds() throws Exception {
+            String softwareName = "software-213030";
+            String softwareVersion = "version-213136";
+            CapabilityStatementSoftwareComponent software = new CapabilityStatementSoftwareComponent()
+                    .setName(softwareName)
+                    .setVersion(softwareVersion);
+            CapabilityStatement statement = new CapabilityStatement().setSoftware(software);
+            when(storeClient.capabilities()).thenReturn(untypedFetch);
+            when(untypedFetch.ofType(CapabilityStatement.class)).thenReturn(typedFetch);
+            when(typedFetch.execute()).thenReturn(statement);
+
+            FeasibilityProcessPluginDeploymentStateListener listener = new FeasibilityProcessPluginDeploymentStateListener(
+                    EvaluationStrategy.CQL, storeClient, flareClient);
+
+            listener.onProcessesDeployed(List.of(FEASIBILITY_EXECUTE_PROCESS_ID));
+            assertThat(out.toString(),
+                    containsString(format("Connection test OK (%s - %s)", softwareName, softwareVersion)));
+    }
+
+    @Test
+    @DisplayName("flare client connection test fails when evaluation strategy is 'structured-query' and error occurs")
+    void flareClientConnectionTestFails() throws Exception {
+        String errorMessage = "error-223236";
+        IOException exception = new IOException(errorMessage);
+        doThrow(exception).when(flareClient).testConnection();
+        FeasibilityProcessPluginDeploymentStateListener listener = new FeasibilityProcessPluginDeploymentStateListener(
+                EvaluationStrategy.STRUCTURED_QUERY, storeClient, flareClient);
+
+        listener.onProcessesDeployed(List.of(FEASIBILITY_EXECUTE_PROCESS_ID));
+
+        assertThat(out.toString(), containsString(format("Connection test FAILED (flare) - error: %s - %s",
+                exception.getClass().getName(), errorMessage)));
+    }
+
+    @Test
+    @DisplayName("store client connection test fails when evaluation strategy is 'cql' and error occurs")
+    void storeClientConnectionTestFails() throws Exception {
+        String errorMessage = "error-223622";
+        RuntimeException exception = new RuntimeException(errorMessage);
+        when(storeClient.capabilities()).thenReturn(untypedFetch);
+        when(untypedFetch.ofType(CapabilityStatement.class)).thenReturn(typedFetch);
+        doThrow(exception).when(typedFetch).execute();
+
+        FeasibilityProcessPluginDeploymentStateListener listener = new FeasibilityProcessPluginDeploymentStateListener(
+                EvaluationStrategy.CQL, storeClient, flareClient);
+
+        listener.onProcessesDeployed(List.of(FEASIBILITY_EXECUTE_PROCESS_ID));
+        assertThat(out.toString(),
+                containsString(format("Connection test FAILED - error: %s - %s", exception.getClass().getName(),
+                        errorMessage)));
+
+    }
+}


### PR DESCRIPTION
Send a simple request on startup to FHIR store or flare depending on configured evaluation strategy and report outcome in logs.

closes #74 